### PR TITLE
Lower Elixir version requirements to v1.2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Exscript.Mixfile do
   def project do
     [app: :exscript,
      version: @vsn,
-     elixir: "~> 1.3",
+     elixir: "~> 1.2",
      deps: deps,
      description: description,
      package: package]


### PR DESCRIPTION
This just lowers the Elixir requirements to v1.2.

Nothing in the code actually requires v1.3 specifically - so it makes sense to allow people to build on v1.2 (not least because I'd benefit :p).