### PR TITLE
Fix an issue compiling on v1.2

### DIFF
--- a/lib/exscript.ex
+++ b/lib/exscript.ex
@@ -131,7 +131,11 @@ defmodule Exscript do
     end)
   end
 
-  defp consolidated_path, do: Mix.Project.consolidation_path(Mix.Project.config)
+  defp consolidated_path do
+    Mix.Project.config
+    |> Mix.Project.build_path
+    |> Path.join("consolidated")
+  end
 
   defp build_comment(user_comment) do
     "%% #{user_comment}\n"


### PR DESCRIPTION
`Mix.Project.consolidation_path/1` doesn't exist on v1.2 Mix. This just cherry picks the contents of that function into Exscript, to makes sure that v1.2 compilation actually does work as intended - otherwise there's an error at runtime.

This time I actually ran some binaries to make sure that they work ok :p I'm sorry for missing it on the previous one - the compiler didn't warn me because it was in another module.